### PR TITLE
Import only used bootstrap css

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -1,5 +1,5 @@
 @import 'scss/shared';
-@import 'bootstrap/scss/bootstrap';
+@import 'scss/bootstrap';
 
 .device-icon > path {
   stroke: #424242;

--- a/frontend/src/scss/_bootstrap.scss
+++ b/frontend/src/scss/_bootstrap.scss
@@ -1,0 +1,51 @@
+ // @import "bootstrap/scss/mixins/banner";
+ // @include bsBanner("");
+
+
+ // scss-docs-start import-stack
+ // Configuration
+ @import "bootstrap/scss/functions";
+ @import "bootstrap/scss/variables";
+ @import "bootstrap/scss/maps";
+ @import "bootstrap/scss/mixins";
+ @import "bootstrap/scss/utilities";
+
+ // Layout & components
+ @import "bootstrap/scss/root";
+ @import "bootstrap/scss/reboot";
+ @import "bootstrap/scss/type";
+ // @import "bootstrap/scss/images";
+ @import "bootstrap/scss/containers";
+ @import "bootstrap/scss/grid";
+ // @import "bootstrap/scss/tables";
+ @import "bootstrap/scss/forms";
+ @import "bootstrap/scss/buttons";
+ // @import "bootstrap/scss/transitions";
+ // @import "bootstrap/scss/dropdown";
+ // @import "bootstrap/scss/button-group";
+ @import "bootstrap/scss/nav";
+ @import "bootstrap/scss/navbar";
+ // @import "bootstrap/scss/card";
+ // @import "bootstrap/scss/accordion";
+ // @import "bootstrap/scss/breadcrumb";
+ // @import "bootstrap/scss/pagination";
+ // @import "bootstrap/scss/badge";
+ // @import "bootstrap/scss/alert";
+ // @import "bootstrap/scss/progress";
+ // @import "bootstrap/scss/list-group";
+ // @import "bootstrap/scss/close";
+ @import "bootstrap/scss/toasts";
+ @import "bootstrap/scss/modal";
+ // @import "bootstrap/scss/tooltip";
+ // @import "bootstrap/scss/popover";
+ @import "bootstrap/scss/carousel";
+ @import "bootstrap/scss/spinners";
+ // @import "bootstrap/scss/offcanvas";
+ // @import "bootstrap/scss/placeholders";
+
+ // Helpers
+ @import "bootstrap/scss/helpers";
+
+ // Utilities
+ @import "bootstrap/scss/utilities/api";
+ // scss-docs-end import-stack


### PR DESCRIPTION
201 to 142 KB. This is still a pain compared to tailwind and we can optimize it more but that would be time consuming (remove classes that we don't use)


![](https://user-images.githubusercontent.com/109829272/185552615-5c2371f0-e485-4933-8573-833b7003e26f.png)

![](https://user-images.githubusercontent.com/109829272/185552620-2fc84dd8-868b-4ba9-804c-ac7dc68c989e.png)
